### PR TITLE
Observe only if connected to DB

### DIFF
--- a/lib/okuribito_rails/railtie.rb
+++ b/lib/okuribito_rails/railtie.rb
@@ -3,7 +3,7 @@ require "okuribito_rails/start_observer"
 module OkuribitoRails
   class Railtie < ::Rails::Railtie
     config.after_initialize do
-      StartObserver.new.start
+      StartObserver.new.start if ActiveRecord::Base.connected?
     end
   end
 end


### PR DESCRIPTION
# Summary

DB との接続が確立している時のみ、`StartObserver.new.start` をコールしてオブザーブを開始する

Invoke `StartObserver.new.start` and start observing only if connected to DB

# Background

例えばローカルで `bundle exec rake assets:precompile` するときに、DB と接続が確立されているとは限らない。

We should not assume that we always connected to DB after initialization.
ex: running `bundle exec rake assets:precompile` on local